### PR TITLE
Fix CIND verifier tests

### DIFF
--- a/src/core/algorithms/algo_factory.cpp
+++ b/src/core/algorithms/algo_factory.cpp
@@ -2,13 +2,18 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <string>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
-#include "core/algorithms/algorithms.h"
-#include "core/algorithms/create_algorithm.h"
+#include <boost/any.hpp>
+
+#include "core/algorithms/algorithm.h"
 #include "core/config/names.h"
+#include "core/config/tabular_data/input_table_type.h"
 #include "core/config/tabular_data/input_tables_type.h"
+#include "core/parser/csv_parser/csv_parser.h"
 
 namespace algos {
 

--- a/src/core/algorithms/algo_factory.h
+++ b/src/core/algorithms/algo_factory.h
@@ -8,7 +8,6 @@
 #include <boost/any.hpp>
 
 #include "core/algorithms/algorithm.h"
-#include "core/algorithms/algorithm_types.h"
 
 namespace algos {
 

--- a/src/core/algorithms/cind/cind_algorithm.cpp
+++ b/src/core/algorithms/cind/cind_algorithm.cpp
@@ -6,7 +6,6 @@
 #include "condition_miners/cinderella.h"
 #include "condition_miners/pli_cind.h"
 #include "core/algorithms/cind/types.h"
-#include "core/algorithms/create_algorithm.h"
 #include "core/config/conditions/algo_type/option.h"
 #include "core/config/conditions/completeness/option.h"
 #include "core/config/conditions/condition_type/option.h"
@@ -28,7 +27,7 @@ CindAlgorithm::CindAlgorithm() {
 }
 
 void CindAlgorithm::CreateSpiderAlgo() {
-    spider_algo_ = CreateAlgorithmInstance<Spider>(AlgorithmType::kSpider);
+    spider_algo_ = std::make_unique<Spider>();
 }
 
 void CindAlgorithm::RegisterSpiderOptions() {

--- a/src/core/algorithms/cind/cind_verifier/cind_verifier.cpp
+++ b/src/core/algorithms/cind/cind_verifier/cind_verifier.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <optional>
 #include <ranges>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -91,18 +92,27 @@ void CINDVerifier::RegisterOptions() {
     model::TableIndex const table_limit = 2;
     RegisterOption(config::kTablesOpt(&input_tables_, table_limit));
 
-    RegisterOption(config::kLhsIndicesOpt(
+    auto const check_uniqueness = [](config::IndicesType const& indices) {
+        std::set<config::IndexType> unique_ids{indices.begin(), indices.end()};
+        if (unique_ids.size() != indices.size()) {
+            throw config::ConfigurationError{"Invalid input: all indices should be unique"};
+        }
+    };
+
+    RegisterOption(config::kLhsRawIndicesOpt(
             &ind_.lhs, [this]() { return input_tables_.front()->GetNumberOfColumns(); },
-            [&rhs = ind_.rhs](config::IndicesType const& indices) {
+            [&rhs = ind_.rhs, check_uniqueness](config::IndicesType const& indices) {
+                check_uniqueness(indices);
                 if (!rhs.empty() && rhs.size() != indices.size()) {
                     throw config::ConfigurationError{
                             "Invalid input: LHS and RHS indices must have the same size"};
                 }
             }));
 
-    RegisterOption(config::kRhsIndicesOpt(
+    RegisterOption(config::kRhsRawIndicesOpt(
             &ind_.rhs, [this]() { return input_tables_.back()->GetNumberOfColumns(); },
-            [&lhs = ind_.lhs](config::IndicesType const& indices) {
+            [&lhs = ind_.lhs, check_uniqueness](config::IndicesType const& indices) {
+                check_uniqueness(indices);
                 if (!lhs.empty() && lhs.size() != indices.size()) {
                     throw config::ConfigurationError{
                             "Invalid input: LHS and RHS indices must have the same size"};
@@ -143,12 +153,6 @@ void CINDVerifier::ResetState() {
 
 void CINDVerifier::LoadDataInternal() {
     encoded_tables_ = std::make_unique<model::EncodedTables>(input_tables_);
-
-    model::TableIndex const lhs_table_idx = 0;
-    auto const& lhs_enc = encoded_tables_->GetTable(lhs_table_idx);
-    if (lhs_enc.GetColumnData().empty() || lhs_enc.GetColumnData().front().GetNumRows() == 0) {
-        throw std::runtime_error("Got an empty LHS table: CIND verification is meaningless.");
-    }
 }
 
 unsigned long long CINDVerifier::ExecuteInternal() {
@@ -163,6 +167,10 @@ void CINDVerifier::VerifyCIND() {
 
     auto const& lhs_enc = encoded_tables_->GetTable(lhs_table_idx);
     auto const& rhs_enc = encoded_tables_->GetTable(rhs_table_idx);
+
+    if (lhs_enc.GetColumnData().empty() || lhs_enc.GetColumnData().front().GetNumRows() == 0) {
+        throw std::runtime_error("Got an empty LHS table: CIND verification is meaningless.");
+    }
 
     bool const same_table = (lhs_table_idx == rhs_table_idx);
 

--- a/src/core/config/conditions/condition_type/option.cpp
+++ b/src/core/config/conditions/condition_type/option.cpp
@@ -5,5 +5,5 @@
 namespace config {
 using names::kConditionType, descriptions::kDConditionType;
 extern CommonOption<algos::cind::CondType> const kConditionTypeOpt{kConditionType, kDConditionType,
-                                                                   algos::cind::CondType::kRow};
+                                                                   algos::cind::CondType::kGroup};
 }  // namespace config

--- a/src/tests/benchmark/CMakeLists.txt
+++ b/src/tests/benchmark/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(
             ${DESBORDANTE_PREFIX}::md::hy
             ${DESBORDANTE_PREFIX}::md::hy::preprocessing
             ${DESBORDANTE_PREFIX}::nar::des
+            ${DESBORDANTE_PREFIX}.compile_feats
             Boost::program_options
             magic_enum::magic_enum
             spdlog::spdlog_header_only

--- a/src/tests/unit/CMakeLists.txt
+++ b/src/tests/unit/CMakeLists.txt
@@ -94,6 +94,32 @@ desbordante_add_test(
     Boost::headers
 )
 
+# --- CIND ---
+desbordante_add_test(
+    cind.algorithms
+    SRCS
+    test_cind_algorithms.cpp
+    LIBS
+    Boost::headers
+    ${DESBORDANTE_PREFIX}::model::table
+    ${DESBORDANTE_PREFIX}::testlib::common
+    ${DESBORDANTE_PREFIX}::cind
+    ${DESBORDANTE_PREFIX}::ind
+)
+
+desbordante_add_test(
+    cind.verifier
+    SRCS
+    test_cind_verifier.cpp
+    LIBS
+    Boost::headers
+    ${DESBORDANTE_PREFIX}::model::table
+    ${DESBORDANTE_PREFIX}::testlib::common
+    ${DESBORDANTE_PREFIX}::cind::verifier
+    ${DESBORDANTE_PREFIX}::ind::verifier
+    ${DESBORDANTE_PREFIX}::ind
+)
+
 # --- CSV ---
 desbordante_add_test(
     csv.parser

--- a/src/tests/unit/CMakeLists.txt
+++ b/src/tests/unit/CMakeLists.txt
@@ -618,6 +618,11 @@ desbordante_add_test(
     ${DESBORDANTE_PREFIX}::model::types
 )
 
+# --- Static map ---
+desbordante_add_test(
+    static_map SRCS test_static_map.cpp LIBS ${DESBORDANTE_PREFIX}::testlib::common
+)
+
 # --- UCC ---
 desbordante_add_test(
     ucc.algos

--- a/src/tests/unit/test_afd_metric_calculator.cpp
+++ b/src/tests/unit/test_afd_metric_calculator.cpp
@@ -4,6 +4,7 @@
 #include "core/algorithms/fd/afd_metric/afd_metric.h"
 #include "core/algorithms/fd/afd_metric/afd_metric_calculator.h"
 #include "core/config/indices/type.h"
+#include "core/config/names.h"
 #include "tests/common/all_csv_configs.h"
 
 namespace tests {

--- a/src/tests/unit/test_cind_algorithms.cpp
+++ b/src/tests/unit/test_cind_algorithms.cpp
@@ -83,26 +83,26 @@ TEST_P(TestCINDConditions, SimpleTest) {
 // clang-format off
 INSTANTIATE_TEST_SUITE_P(
     CINDTestSuite, TestCINDConditions, ::testing::Values(
-        CINDConditionsParams(algos::cind::AlgoType::cinderella, algos::cind::CondType::row, 0.0, 0.01, 61),
-        CINDConditionsParams(algos::cind::AlgoType::cinderella, algos::cind::CondType::row, 0.0, 0.15, 23),
-        CINDConditionsParams(algos::cind::AlgoType::cinderella, algos::cind::CondType::row, 0.0, 0.56, 3),
-        CINDConditionsParams(algos::cind::AlgoType::cinderella, algos::cind::CondType::row, 1.0, 0.01, 56),
-        CINDConditionsParams(algos::cind::AlgoType::cinderella, algos::cind::CondType::row, 1.0, 0.15, 18),
-        CINDConditionsParams(algos::cind::AlgoType::cinderella, algos::cind::CondType::row, 1.0, 0.56, 2),
-        CINDConditionsParams(algos::cind::AlgoType::pli_cind, algos::cind::CondType::row, 0.0, 0.01, 61),
-        CINDConditionsParams(algos::cind::AlgoType::pli_cind, algos::cind::CondType::row, 0.0, 0.15, 23),
-        CINDConditionsParams(algos::cind::AlgoType::pli_cind, algos::cind::CondType::row, 0.0, 0.56, 3),
-        CINDConditionsParams(algos::cind::AlgoType::pli_cind, algos::cind::CondType::row, 1.0, 0.01, 56),
-        CINDConditionsParams(algos::cind::AlgoType::pli_cind, algos::cind::CondType::row, 1.0, 0.15, 18),
-        CINDConditionsParams(algos::cind::AlgoType::pli_cind, algos::cind::CondType::row, 1.0, 0.56, 2),
-        CINDConditionsParams(algos::cind::AlgoType::cinderella, algos::cind::CondType::group, 0.1, 0.4, 61),
-        CINDConditionsParams(algos::cind::AlgoType::cinderella, algos::cind::CondType::group, 0.1, 0.6, 1),
-        CINDConditionsParams(algos::cind::AlgoType::cinderella, algos::cind::CondType::group, 0.75, 0.4, 56),
-        CINDConditionsParams(algos::cind::AlgoType::cinderella, algos::cind::CondType::group, 0.75, 0.6, 0),
-        CINDConditionsParams(algos::cind::AlgoType::pli_cind, algos::cind::CondType::group, 0.1, 0.4, 61),
-        CINDConditionsParams(algos::cind::AlgoType::pli_cind, algos::cind::CondType::group, 0.1, 0.6, 1),
-        CINDConditionsParams(algos::cind::AlgoType::pli_cind, algos::cind::CondType::group, 0.75, 0.4, 56),
-        CINDConditionsParams(algos::cind::AlgoType::pli_cind, algos::cind::CondType::group, 0.75, 0.6, 0)
+        CINDConditionsParams(algos::cind::AlgoType::kCinderella, algos::cind::CondType::kRow, 0.0, 0.01, 61),
+        CINDConditionsParams(algos::cind::AlgoType::kCinderella, algos::cind::CondType::kRow, 0.0, 0.15, 23),
+        CINDConditionsParams(algos::cind::AlgoType::kCinderella, algos::cind::CondType::kRow, 0.0, 0.56, 3),
+        CINDConditionsParams(algos::cind::AlgoType::kCinderella, algos::cind::CondType::kRow, 1.0, 0.01, 56),
+        CINDConditionsParams(algos::cind::AlgoType::kCinderella, algos::cind::CondType::kRow, 1.0, 0.15, 18),
+        CINDConditionsParams(algos::cind::AlgoType::kCinderella, algos::cind::CondType::kRow, 1.0, 0.56, 2),
+        CINDConditionsParams(algos::cind::AlgoType::kPliCind, algos::cind::CondType::kRow, 0.0, 0.01, 61),
+        CINDConditionsParams(algos::cind::AlgoType::kPliCind, algos::cind::CondType::kRow, 0.0, 0.15, 23),
+        CINDConditionsParams(algos::cind::AlgoType::kPliCind, algos::cind::CondType::kRow, 0.0, 0.56, 3),
+        CINDConditionsParams(algos::cind::AlgoType::kPliCind, algos::cind::CondType::kRow, 1.0, 0.01, 56),
+        CINDConditionsParams(algos::cind::AlgoType::kPliCind, algos::cind::CondType::kRow, 1.0, 0.15, 18),
+        CINDConditionsParams(algos::cind::AlgoType::kPliCind, algos::cind::CondType::kRow, 1.0, 0.56, 2),
+        CINDConditionsParams(algos::cind::AlgoType::kCinderella, algos::cind::CondType::kGroup, 0.1, 0.4, 61),
+        CINDConditionsParams(algos::cind::AlgoType::kCinderella, algos::cind::CondType::kGroup, 0.1, 0.6, 1),
+        CINDConditionsParams(algos::cind::AlgoType::kCinderella, algos::cind::CondType::kGroup, 0.75, 0.4, 56),
+        CINDConditionsParams(algos::cind::AlgoType::kCinderella, algos::cind::CondType::kGroup, 0.75, 0.6, 0),
+        CINDConditionsParams(algos::cind::AlgoType::kPliCind, algos::cind::CondType::kGroup, 0.1, 0.4, 61),
+        CINDConditionsParams(algos::cind::AlgoType::kPliCind, algos::cind::CondType::kGroup, 0.1, 0.6, 1),
+        CINDConditionsParams(algos::cind::AlgoType::kPliCind, algos::cind::CondType::kGroup, 0.75, 0.4, 56),
+        CINDConditionsParams(algos::cind::AlgoType::kPliCind, algos::cind::CondType::kGroup, 0.75, 0.6, 0)
     ));
 // clang-format on
 

--- a/src/tests/unit/test_dd_verifier.cpp
+++ b/src/tests/unit/test_dd_verifier.cpp
@@ -7,6 +7,7 @@
 #include "core/algorithms/dd/dd_verifier/FuncMetric.h"
 #include "core/algorithms/dd/dd_verifier/Metric.h"
 #include "core/algorithms/dd/dd_verifier/dd_verifier.h"
+#include "core/config/names.h"
 #include "tests/common/all_csv_configs.h"
 
 namespace tests {

--- a/src/tests/unit/test_dynamic_fd_verifier.cpp
+++ b/src/tests/unit/test_dynamic_fd_verifier.cpp
@@ -6,6 +6,7 @@
 #include "core/algorithms/algo_factory.h"
 #include "core/algorithms/fd/fd_verifier/dynamic_fd_verifier.h"
 #include "core/algorithms/fd/fd_verifier/dynamic_stats_calculator.h"
+#include "core/algorithms/fd/fd_verifier/stats_calculator.h"
 #include "core/config/exceptions.h"
 #include "core/config/indices/type.h"
 #include "core/config/names.h"

--- a/src/tests/unit/test_fd_util.h
+++ b/src/tests/unit/test_fd_util.h
@@ -3,7 +3,9 @@
 #include <gtest/gtest.h>
 
 #include "core/algorithms/algo_factory.h"
+#include "core/algorithms/fd/eulerfd/eulerfd.h"
 #include "core/algorithms/fd/fd_algorithm.h"
+#include "core/algorithms/fd/pyrocommon/core/parameters.h"
 #include "core/config/error/type.h"
 #include "core/config/names.h"
 #include "tests/common/all_csv_configs.h"

--- a/src/tests/unit/test_gfd_validator.cpp
+++ b/src/tests/unit/test_gfd_validator.cpp
@@ -2,7 +2,9 @@
 #include <gtest/gtest.h>
 
 #include "core/algorithms/algo_factory.h"
+#include "core/algorithms/gfd/gfd_validator/egfd_validator.h"
 #include "core/algorithms/gfd/gfd_validator/gfd_validator.h"
+#include "core/algorithms/gfd/gfd_validator/naivegfd_validator.h"
 #include "core/config/names.h"
 #include "tests/unit/all_gfd_paths.h"
 

--- a/src/tests/unit/test_hymd.cpp
+++ b/src/tests/unit/test_hymd.cpp
@@ -10,6 +10,7 @@
 
 #include "core/algorithms/algo_factory.h"
 #include "core/algorithms/md/decision_boundary.h"
+#include "core/algorithms/md/hymd/hymd.h"
 #include "core/algorithms/md/hymd/preprocessing/column_matches/levenshtein.h"
 #include "core/algorithms/md/hymd/utility/md_less.h"
 #include "core/config/names.h"

--- a/src/tests/unit/test_ind_algorithms.cpp
+++ b/src/tests/unit/test_ind_algorithms.cpp
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
 
 #include "core/algorithms/algo_factory.h"
+#include "core/algorithms/ind/faida/faida.h"
+#include "core/algorithms/ind/mind/mind.h"
+#include "core/algorithms/ind/spider/spider.h"
 #include "core/config/equal_nulls/type.h"
 #include "core/config/error/type.h"
 #include "core/config/max_arity/type.h"

--- a/src/tests/unit/test_set_based_verifier.cpp
+++ b/src/tests/unit/test_set_based_verifier.cpp
@@ -3,8 +3,11 @@
 #include <gtest/gtest.h>
 
 #include "core/algorithms/algo_factory.h"
+#include "core/algorithms/od/fastod/fastod.h"
+#include "core/algorithms/od/fastod/model/canonical_od.h"
 #include "core/algorithms/od/fastod/model/removal_set.h"
 #include "core/algorithms/od/set_based_verifier/verifier.h"
+#include "core/config/names.h"
 #include "tests/common/all_csv_configs.h"
 
 namespace tests {

--- a/src/tests/unit/test_split.cpp
+++ b/src/tests/unit/test_split.cpp
@@ -6,6 +6,8 @@
 #include <gtest/gtest.h>
 
 #include "core/algorithms/algo_factory.h"
+#include "core/algorithms/dd/dd.h"
+#include "core/algorithms/dd/split/split.h"
 #include "core/config/names.h"
 #include "tests/common/all_csv_configs.h"
 #include "tests/common/csv_config_util.h"

--- a/src/tests/unit/test_ucc_algorithms.cpp
+++ b/src/tests/unit/test_ucc_algorithms.cpp
@@ -7,7 +7,9 @@
 #include <gtest/gtest.h>
 
 #include "core/algorithms/algo_factory.h"
+#include "core/algorithms/ucc/hpivalid/hpivalid.h"
 #include "core/algorithms/ucc/hyucc/hyucc.h"
+#include "core/algorithms/ucc/pyroucc/pyroucc.h"
 #include "core/algorithms/ucc/ucc.h"
 #include "core/algorithms/ucc/ucc_algorithm.h"
 #include "core/config/names.h"

--- a/src/tests/unit/test_ucc_verifier.cpp
+++ b/src/tests/unit/test_ucc_verifier.cpp
@@ -1,9 +1,12 @@
 #include <gtest/gtest.h>
 
 #include "core/algorithms/algo_factory.h"
+#include "core/algorithms/ucc/hyucc/hyucc.h"
+#include "core/algorithms/ucc/ucc.h"
 #include "core/algorithms/ucc/ucc_verifier/ucc_verifier.h"
 #include "core/config/indices/type.h"
 #include "core/config/names.h"
+#include "core/config/thread_number/type.h"
 #include "tests/common/all_csv_configs.h"
 
 namespace tests {


### PR DESCRIPTION
Empty-table check in Execute, group condition type by default, raw indices with uniqueness